### PR TITLE
Patch third_party\nasm to keep 'default_crt'

### DIFF
--- a/build_win.bat
+++ b/build_win.bat
@@ -17,6 +17,9 @@ call git apply ..\code.patch
 cd build
 call git apply ..\..\build_win.patch
 cd ..
+cd third_party\nasm
+call git apply ..\..\..\build_win_nasm.patch
+cd ..\..
 mkdir out
 cd out
 mkdir Release

--- a/build_win_nasm.patch
+++ b/build_win_nasm.patch
@@ -1,0 +1,16 @@
+diff --git a/BUILD.gn b/BUILD.gn
+index 2c6981e6..69ec1814 100644
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -36,8 +36,9 @@ if (is_debug) {
+   if (is_win) {
+     # This switches to using the release CRT. For yasm debug component builds
+     # of highbd_sad4d_sse2.asm on Windows this saved about 15 s.
+-    configs_to_delete += [ "//build/config/win:default_crt" ]
+-    configs_to_add += [ "//build/config/win:release_crt" ]
++    # Actually, for GDAL context, stick to default_crt
++    #configs_to_delete += [ "//build/config/win:default_crt" ]
++    #configs_to_add += [ "//build/config/win:release_crt" ]
+ 
+     # Without no_default_deps, an implicit dependency on libc++ is added.
+     # libc++ may have been built referencing the debug CRT, but since we're


### PR DESCRIPTION
* Switching to 'release_crt' ends up mixing /MD & /MT

Running `ninja -t commands` revealed that both `/MD` and `/MT` were being used in the build.